### PR TITLE
chore: bump compatibility range

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("232")
-        untilBuild.set("241.*")
+        untilBuild.set("242.*")
     }
 
     signPlugin {


### PR DESCRIPTION
Marks as compatible with 2024.2.